### PR TITLE
Erro de digitação corrigido

### DIFF
--- a/Lambda_Calculus/slides/definicao/introducao.tex
+++ b/Lambda_Calculus/slides/definicao/introducao.tex
@@ -13,9 +13,9 @@
             noção de computabilidade
 
         \item Qualquer função computável pode ser expressa e avaliada através do cálculo $\lambda$,
-            de modo que ele é equivalente às máquinas de Turin
+            de modo que ele é equivalente às máquinas de Turing
             
-        \item Ao contrário das máquinas de Turin, o foco é o uso das regras de transformações, 
+        \item Ao contrário das máquinas de Turing, o foco é o uso das regras de transformações, 
             sendo mais próximo do software do que do hardware
     \end{itemize}
 


### PR DESCRIPTION
"máquinas de Turin" corrigido para "máquinas de Turing"